### PR TITLE
Add Python-based WhatsApp OpenAI bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+conversations.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# Bot
+# Bot de WhatsApp con OpenAI
+
+Este proyecto contiene una configuraci\u00f3n inicial para crear un bot de WhatsApp que use la API de OpenAI para responder mensajes. Incluye un dashboard web sencillo donde se almacenan las conversaciones.
+
+## Requisitos
+
+- Python 3.8+
+- Definir la variable de entorno `OPENAI_API_KEY` con tu clave de OpenAI.
+
+## Uso
+
+1. Instala las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ejecuta el servidor:
+   ```bash
+   python app.py
+   ```
+3. Env\u00eda mensajes POST a `/webhook` con el formato `{ "from": "usuario", "message": "hola" }`.
+4. Visita `http://localhost:3000/dashboard` para ver las conversaciones almacenadas.
+
+Este c\u00f3digo es una base que se puede ampliar con la integraci\u00f3n real de la API de WhatsApp y un an\u00e1lisis m\u00e1s completo de las conversaciones.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, request, jsonify, send_from_directory
+from services.openai_client import get_completion
+from services.storage import load_conversations, save_conversation
+import os
+
+app = Flask(__name__, static_folder='public')
+
+
+@app.post('/webhook')
+def webhook():
+    data = request.get_json(force=True)
+    user = data.get('from')
+    message = data.get('message')
+    if not user or not message:
+        return jsonify({'error': 'Formato invalido'}), 400
+    try:
+        reply = get_completion(message)
+        conv = save_conversation(user, message, reply)
+        return jsonify({'reply': reply, 'conv': conv})
+    except Exception as e:
+        print(e)
+        return jsonify({'error': 'Error procesando mensaje'}), 500
+
+
+@app.get('/dashboard')
+def dashboard():
+    return send_from_directory(app.static_folder, 'dashboard.html')
+
+
+@app.get('/api/conversations')
+def api_conversations():
+    return jsonify(load_conversations())
+
+
+if __name__ == '__main__':
+    port = int(os.getenv('PORT', 3000))
+    app.run(host='0.0.0.0', port=port)

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard de Conversaciones</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .conv { margin-bottom: 20px; padding-bottom: 10px; border-bottom: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <h1>Conversaciones</h1>
+  <div id="conversations"></div>
+
+  <script>
+    async function load() {
+      const res = await fetch('/api/conversations');
+      const data = await res.json();
+      const container = document.getElementById('conversations');
+      container.innerHTML = '';
+      data.forEach(conv => {
+        const div = document.createElement('div');
+        div.className = 'conv';
+        div.innerHTML = '<h3>Usuario: ' + conv.user + '</h3>' +
+          conv.messages.map(m => '<p><b>Mensaje:</b> ' + m.message + '<br/><b>Respuesta:</b> ' + m.reply + '</p>').join('');
+        container.appendChild(div);
+      });
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/services/openai_client.py
+++ b/services/openai_client.py
@@ -1,0 +1,25 @@
+import os
+import openai
+
+openai.api_key = os.environ.get('OPENAI_API_KEY')
+
+
+def get_completion(message: str) -> str:
+    """Genera una respuesta usando la API de OpenAI."""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": message}],
+    )
+    return response.choices[0].message["content"].strip()
+
+
+def analyze_conversation(text: str) -> str:
+    """Eval\u00faa el tono de la conversaci\u00f3n."""
+    prompt = (
+        "Califica el siguiente texto del 1 al 5 segun su tono positivo:\n" + text
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"].strip()

--- a/services/storage.py
+++ b/services/storage.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "conversations.json"
+
+
+def load_conversations():
+    if not DATA_FILE.exists():
+        return []
+    with DATA_FILE.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_conversation(user: str, message: str, reply: str):
+    convs = load_conversations()
+    existing = next((c for c in convs if c.get("user") == user), None)
+    if existing is None:
+        existing = {"user": user, "messages": []}
+        convs.append(existing)
+    existing["messages"].append({"message": message, "reply": reply})
+    with DATA_FILE.open("w", encoding="utf-8") as f:
+        json.dump(convs, f, indent=2, ensure_ascii=False)
+    return existing


### PR DESCRIPTION
## Summary
- replace Node implementation with Python (Flask) server
- add OpenAI client and simple JSON storage in Python
- update dashboard and usage instructions
- include requirements file and ignore Python cache

## Testing
- `python -m py_compile app.py services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685c8c4ef5cc832384722b3db50e144e